### PR TITLE
Registry additions

### DIFF
--- a/README.org
+++ b/README.org
@@ -1273,6 +1273,7 @@ When looking at a macro's binding site, ask yourself:
 | ~pcase-let*~                     | core     | custom    |       |          | pcase-let*       | done   | extract-pcase-let*   |
 | ~pcase-dolist~                   | core     | custom    |       |          | pcase-dolist     | done   | extract-pcase-dolist |
 | ~pcase-lambda~                   | core     | custom    |       |          | pcase-λ          | done   | extract-pcase-lambda |
+| ~map-let~                        | core     | custom    |       |          | map-let          | done   | extract-map-let |
 
 
 - Deferred (core forms needing custom extractors) :: I'm leaving these for last,

--- a/README.org
+++ b/README.org
@@ -1209,66 +1209,70 @@ When looking at a macro's binding site, ask yourself:
 - Implemented forms :: these forms were registered and tested, do let me know if
   you get erroneous autocompletion candidates from any of these.
 
-| Symbol                           | Package  | Shape     | Index | Scope    | Tag                | Status | Extractor         |
-|----------------------------------+----------+-----------+-------+----------+--------------------+--------+-------------------|
-| ~let~                            | core     | list      |     1 | body     | "let"              | done   |                   |
-| ~let*~                           | core     | list      |     1 | body     | "let*"             | done   |                   |
-| ~when-let*~                      | core     | list      |     1 | body     | "when-let*"        | done   |                   |
-| ~and-let*~                       | core     | list      |     1 | body     | "and-let*"         | done   |                   |
-| ~dlet~                           | core     | list      |     1 | body     | "dlet"             | done   |                   |
-| ~letrec~                         | core     | list      |     1 | body     | "letrec"           | done   |                   |
-| ~cl-do~                          | core     | list      |     1 | body     | "cl-do"            | done   |                   |
-| ~cl-do*~                         | core     | list      |     1 | body     | "cl-do*"           | done   |                   |
-| ~cl-symbol-macrolet~             | core     | list      |     1 | body     | "cl-sym-mlet"      | done   |                   |
-| ~with-slots~                     | core     | list      |     1 | body     | "with-slots"       | done   |                   |
-| ~if-let~                         | core     | list      |     1 | then     | "if-let"           | done   |                   |
-| ~if-let*~                        | core     | list      |     1 | then     | "if-let*"          | done   |                   |
-| ~lambda~                         | core     | arglist   |     1 | body     | "arg"              | done   |                   |
-| ~cl-destructuring-bind~          | core     | arglist   |     1 | body     | "arg"              | done   |                   |
-| ~cl-multiple-value-bind~         | core     | arglist   |     1 | body     | "cl-multi-vbind"   | done   |                   |
-| ~cl-multiple-value-setq~         | core     | arglist   |     1 | body     | "cl-multi-vsetq"   | done   |                   |
-| ~cl-with-gensyms~                | core     | arglist   |     1 | body     | "cl-wgensyms"      | done   |                   |
-| ~cl-once-only~                   | core     | arglist   |     1 | body     | "cl-once-only"     | done   |                   |
-| ~defun~                          | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~defmacro~                       | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~defsubst~                       | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~cl-defun~                       | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~cl-defmacro~                    | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~cl-defsubst~                    | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~define-inline~                  | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~cl-defgeneric~                  | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~iter-defun~                     | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~cl-iter-defun~                  | core     | arglist   |     2 | body     | "arg"              | done   |                   |
-| ~dolist~                         | core     | single    |     1 | body     | "dolist"           | done   |                   |
-| ~dotimes~                        | core     | single    |     1 | body     | "dotimes"          | done   |                   |
-| ~cl-do-symbols~                  | core     | single    |     1 | body     | "cl-do-symbols"    | done   |                   |
-| ~cl-do-all-symbols~              | core     | single    |     1 | body     | "cl-do-all-sym"    | done   |                   |
-| ~dolist-with-progress-reporter~  | core     | single    |     1 | body     | "dolist-pr"        | done   |                   |
-| ~dotimes-with-progress-reporter~ | core     | single    |     1 | body     | "dotimes-pr"       | done   |                   |
-| ~condition-case~                 | core     | error-var |     1 | handlers | "cond-case"        | done   |                   |
-| ~condition-case-unless-debug~    | core     | error-var |     1 | handlers | "cond-case"        | done   |                   |
-| ~ert-with-temp-file~             | core     | error-var |     1 | body     | "ert-tmp-file"     | done   |                   |
-| ~ert-with-temp-directory~        | core     | error-var |     1 | body     | "ert-tmp-dir"      | done   |                   |
-| ~ert-with-message-capture~       | core     | error-var |     1 | body     | "ert-msg-cap"      | done   |                   |
-| ~cl-defmethod~                   | core     | custom    |       |          | "cl-defmethod"     | done   | extract-defmethod |
-| ~cl-flet~                        | core     | custom    |       |          | "cl-flet"          | done   | extract-flet      |
-| ~cl-flet*~                       | core     | custom    |       |          | "cl-flet*"         | done   | extract-flet      |
-| ~cl-labels~                      | core     | custom    |       |          | "cl-labels"        | done   | extract-flet      |
-| ~cl-macrolet~                    | core     | custom    |       |          | "cl-macrolet"      | done   | extract-flet      |
-| ~cl-letf~                        | core     | custom    |       |          | "cl-letf"          | done   | extract-letf      |
-| ~cl-letf*~                       | core     | custom    |       |          | "cl-letf*"         | done   | extract-letf      |
-| ~seq-let~                        | core     | custom    |       |          | "seq-let"          | done   | extract-seq-let   |
-| ~named-let~                      | core     | custom    |       |          | "named-let"        |        | extract-named-let |
-| ~cond-let--and-let*~             | cond-let | list      |     1 | body     | "cond-and-let*"    | done   |                   |
-| ~cond-let--and-let~              | cond-let | list      |     1 | body     | "cond-and-let"     | done   |                   |
-| ~cond-let--when-let*~            | cond-let | list      |     1 | body     | "cond-when-let*"   | done   |                   |
-| ~cond-let--when-let~             | cond-let | list      |     1 | body     | "cond-when-let"    | done   |                   |
-| ~cond-let--while-let*~           | cond-let | list      |     1 | body     | "cond-while-let*"  | done   |                   |
-| ~cond-let--while-let~            | cond-let | list      |     1 | body     | "cond-while-let"   | done   |                   |
-| ~cond-let--if-let*~              | cond-let | list      |     1 | then     | "cond-if-let*"     | done   |                   |
-| ~cond-let--if-let~               | cond-let | list      |     1 | then     | "cond-if-let"      | done   |                   |
-| ~seq-doseq~                      | core     | single    |       |          | "doseq"            | done   |                   |
-| ~let-when-compile~               | core     | list      |     1 | body     | "let-when-compile" | done   |                   |
+| Symbol                           | Package  | Shape     | Index | Scope    | Tag              | Status | Extractor            |
+|----------------------------------+----------+-----------+-------+----------+------------------+--------+----------------------|
+| ~let~                            | core     | list      |     1 | body     | let              | done   |                      |
+| ~let*~                           | core     | list      |     1 | body     | let*             | done   |                      |
+| ~when-let*~                      | core     | list      |     1 | body     | when-let*        | done   |                      |
+| ~and-let*~                       | core     | list      |     1 | body     | and-let*         | done   |                      |
+| ~dlet~                           | core     | list      |     1 | body     | dlet             | done   |                      |
+| ~letrec~                         | core     | list      |     1 | body     | letrec           | done   |                      |
+| ~cl-do~                          | core     | list      |     1 | body     | cl-do            | done   |                      |
+| ~cl-do*~                         | core     | list      |     1 | body     | cl-do*           | done   |                      |
+| ~cl-symbol-macrolet~             | core     | list      |     1 | body     | cl-sym-mlet      | done   |                      |
+| ~with-slots~                     | core     | list      |     1 | body     | with-slots       | done   |                      |
+| ~if-let~                         | core     | list      |     1 | then     | if-let           | done   |                      |
+| ~if-let*~                        | core     | list      |     1 | then     | if-let*          | done   |                      |
+| ~let-when-compile~               | core     | list      |     1 | body     | let-when-compile | done   |                      |
+| ~lambda~                         | core     | arglist   |     1 | body     | arg              | done   |                      |
+| ~cl-destructuring-bind~          | core     | arglist   |     1 | body     | arg              | done   |                      |
+| ~cl-multiple-value-bind~         | core     | arglist   |     1 | body     | cl-multi-vbind   | done   |                      |
+| ~cl-multiple-value-setq~         | core     | arglist   |     1 | body     | cl-multi-vsetq   | done   |                      |
+| ~cl-with-gensyms~                | core     | arglist   |     1 | body     | cl-wgensyms      | done   |                      |
+| ~cl-once-only~                   | core     | arglist   |     1 | body     | cl-once-only     | done   |                      |
+| ~defun~                          | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~defmacro~                       | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~defsubst~                       | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~cl-defun~                       | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~cl-defmacro~                    | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~cl-defsubst~                    | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~define-inline~                  | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~cl-defgeneric~                  | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~iter-defun~                     | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~cl-iter-defun~                  | core     | arglist   |     2 | body     | arg              | done   |                      |
+| ~dolist~                         | core     | single    |     1 | body     | dolist           | done   |                      |
+| ~dotimes~                        | core     | single    |     1 | body     | dotimes          | done   |                      |
+| ~cl-do-symbols~                  | core     | single    |     1 | body     | cl-do-symbols    | done   |                      |
+| ~cl-do-all-symbols~              | core     | single    |     1 | body     | cl-do-all-sym    | done   |                      |
+| ~dolist-with-progress-reporter~  | core     | single    |     1 | body     | dolist-pr        | done   |                      |
+| ~dotimes-with-progress-reporter~ | core     | single    |     1 | body     | dotimes-pr       | done   |                      |
+| ~seq-doseq~                      | core     | single    |       |          | doseq            | done   |                      |
+| ~condition-case~                 | core     | error-var |     1 | handlers | cond-case        | done   |                      |
+| ~condition-case-unless-debug~    | core     | error-var |     1 | handlers | cond-case        | done   |                      |
+| ~ert-with-temp-file~             | core     | error-var |     1 | body     | ert-tmp-file     | done   |                      |
+| ~ert-with-temp-directory~        | core     | error-var |     1 | body     | ert-tmp-dir      | done   |                      |
+| ~ert-with-message-capture~       | core     | error-var |     1 | body     | ert-msg-cap      | done   |                      |
+| ~cond-let--and-let*~             | cond-let | list      |     1 | body     | cond-and-let*    | done   |                      |
+| ~cond-let--and-let~              | cond-let | list      |     1 | body     | cond-and-let     | done   |                      |
+| ~cond-let--when-let*~            | cond-let | list      |     1 | body     | cond-when-let*   | done   |                      |
+| ~cond-let--when-let~             | cond-let | list      |     1 | body     | cond-when-let    | done   |                      |
+| ~cond-let--while-let*~           | cond-let | list      |     1 | body     | cond-while-let*  | done   |                      |
+| ~cond-let--while-let~            | cond-let | list      |     1 | body     | cond-while-let   | done   |                      |
+| ~cond-let--if-let*~              | cond-let | list      |     1 | then     | cond-if-let*     | done   |                      |
+| ~cond-let--if-let~               | cond-let | list      |     1 | then     | cond-if-let      | done   |                      |
+| ~cl-defmethod~                   | core     | custom    |       |          | cl-defmethod     | done   | extract-defmethod    |
+| ~cl-flet~                        | core     | custom    |       |          | cl-flet          | done   | extract-flet         |
+| ~cl-flet*~                       | core     | custom    |       |          | cl-flet*         | done   | extract-flet         |
+| ~cl-labels~                      | core     | custom    |       |          | cl-labels        | done   | extract-flet         |
+| ~cl-macrolet~                    | core     | custom    |       |          | cl-macrolet      | done   | extract-flet         |
+| ~cl-letf~                        | core     | custom    |       |          | cl-letf          | done   | extract-letf         |
+| ~cl-letf*~                       | core     | custom    |       |          | cl-letf*         | done   | extract-letf         |
+| ~seq-let~                        | core     | custom    |       |          | seq-let          | done   | extract-seq-let      |
+| ~named-let~                      | core     | custom    |       |          | named-let        | done   | extract-named-let    |
+| ~pcase-let~                      | core     | custom    |       |          | pcase-let        | done   | extract-pcase-let    |
+| ~pcase-let*~                     | core     | custom    |       |          | pcase-let*       | done   | extract-pcase-let*   |
+| ~pcase-dolist~                   | core     | custom    |       |          | pcase-dolist     | done   | extract-pcase-dolist |
+| ~pcase-lambda~                   | core     | custom    |       |          | pcase-λ          | done   | extract-pcase-lambda |
 
 
 - Deferred (core forms needing custom extractors) :: I'm leaving these for last,
@@ -1276,15 +1280,11 @@ When looking at a macro's binding site, ask yourself:
   signatures (specially cl-loop and dash). I'm NOT going by order, got
   sidetracked by other forms.
 
-| Symbol          | Package  | Reason                                             | Complexity | Status          |
-|-----------------+----------+----------------------------------------------------+------------+-----------------|
-| ~pcase-let~       | core     | Recursive pattern walker, complex edge cases       | MEDIUM     | In Progress     |
-| ~pcase-let*~      | core     | Same                                               | MEDIUM     | In Progress     |
-| ~pcase-dolist~    | core     | Same                                               | MEDIUM     | In Progress     |
-| ~pcase-lambda~    | core     | Same                                               | MEDIUM     | In Progress     |
-| ~cond-let--and$~  | cond-let | Binds fixed name ~$~, no user-written symbol         | LOW        |                 |
-| ~cond-let--when$~ | cond-let | Binds fixed name ~$~, no user-written symbol         | LOW        |                 |
-| ~cond-let--and>~  | cond-let | Binds fixed name ~$~ repeatedly                      | LOW        |                 |
+| Symbol            | Package  | Reason                                             | Complexity | Status          |
+|-------------------+----------+----------------------------------------------------+------------+-----------------|
+| ~cond-let--and$~  | cond-let | Binds fixed name ~$~, no user-written symbol       | LOW        |                 |
+| ~cond-let--when$~ | cond-let | Binds fixed name ~$~, no user-written symbol       | LOW        |                 |
+| ~cond-let--and>~  | cond-let | Binds fixed name ~$~ repeatedly                    | LOW        |                 |
 | ~cond-let*~       | cond-let | Vector clause syntax, cross-clause scope           | HIGH       |                 |
 | ~cond-let~        | cond-let | Vector clause syntax, cross-clause scope           | HIGH       |                 |
 | ~-lambda~         | dash     | Dash pattern language needs custom extractor       | MEDIUM     |                 |

--- a/README.org
+++ b/README.org
@@ -1223,7 +1223,6 @@ When looking at a macro's binding site, ask yourself:
 | ~with-slots~                     | core     | list      |     1 | body     | "with-slots"       | done   |                   |
 | ~if-let~                         | core     | list      |     1 | then     | "if-let"           | done   |                   |
 | ~if-let*~                        | core     | list      |     1 | then     | "if-let*"          | done   |                   |
-| ~named-let~                      | core     | list      |     2 | body     | "named-let"        | done   |                   |
 | ~lambda~                         | core     | arglist   |     1 | body     | "arg"              | done   |                   |
 | ~cl-destructuring-bind~          | core     | arglist   |     1 | body     | "arg"              | done   |                   |
 | ~cl-multiple-value-bind~         | core     | arglist   |     1 | body     | "cl-multi-vbind"   | done   |                   |
@@ -1258,6 +1257,8 @@ When looking at a macro's binding site, ask yourself:
 | ~cl-macrolet~                    | core     | custom    |       |          | "cl-macrolet"      | done   | extract-flet      |
 | ~cl-letf~                        | core     | custom    |       |          | "cl-letf"          | done   | extract-letf      |
 | ~cl-letf*~                       | core     | custom    |       |          | "cl-letf*"         | done   | extract-letf      |
+| ~seq-let~                        | core     | custom    |       |          | "seq-let"          | done   | extract-seq-let   |
+| ~named-let~                      | core     | custom    |       |          | "named-let"        |        | extract-named-let |
 | ~cond-let--and-let*~             | cond-let | list      |     1 | body     | "cond-and-let*"    | done   |                   |
 | ~cond-let--and-let~              | cond-let | list      |     1 | body     | "cond-and-let"     | done   |                   |
 | ~cond-let--when-let*~            | cond-let | list      |     1 | body     | "cond-when-let*"   | done   |                   |
@@ -1266,7 +1267,6 @@ When looking at a macro's binding site, ask yourself:
 | ~cond-let--while-let~            | cond-let | list      |     1 | body     | "cond-while-let"   | done   |                   |
 | ~cond-let--if-let*~              | cond-let | list      |     1 | then     | "cond-if-let*"     | done   |                   |
 | ~cond-let--if-let~               | cond-let | list      |     1 | then     | "cond-if-let"      | done   |                   |
-| ~seq-let~                        | core     | list      |     1 | body     | "seq-let"          | done   | extract-seq-let   |
 | ~seq-doseq~                      | core     | single    |       |          | "doseq"            | done   |                   |
 | ~let-when-compile~               | core     | list      |     1 | body     | "let-when-compile" | done   |                   |
 

--- a/README.org
+++ b/README.org
@@ -1209,69 +1209,72 @@ When looking at a macro's binding site, ask yourself:
 - Implemented forms :: these forms were registered and tested, do let me know if
   you get erroneous autocompletion candidates from any of these.
 
-| Symbol                         | Package  | Shape     | Index | Scope    | Tag              | Status | Extractor         |
-|--------------------------------+----------+-----------+-------+----------+------------------+--------+-------------------|
-| ~let~                            | core     | list      |     1 | body     | "let"            | done   |                   |
-| ~let*~                           | core     | list      |     1 | body     | "let*"           | done   |                   |
-| ~when-let*~                      | core     | list      |     1 | body     | "when-let*"      | done   |                   |
-| ~and-let*~                       | core     | list      |     1 | body     | "and-let*"       | done   |                   |
-| ~dlet~                           | core     | list      |     1 | body     | "dlet"           | done   |                   |
-| ~letrec~                         | core     | list      |     1 | body     | "letrec"         | done   |                   |
-| ~cl-do~                          | core     | list      |     1 | body     | "cl-do"          | done   |                   |
-| ~cl-do*~                         | core     | list      |     1 | body     | "cl-do*"         | done   |                   |
-| ~cl-symbol-macrolet~             | core     | list      |     1 | body     | "cl-sym-mlet"    | done   |                   |
-| ~with-slots~                     | core     | list      |     1 | body     | "with-slots"     | done   |                   |
-| ~if-let~                         | core     | list      |     1 | then     | "if-let"         | done   |                   |
-| ~if-let*~                        | core     | list      |     1 | then     | "if-let*"        | done   |                   |
-| ~named-let~                      | core     | list      |     2 | body     | "named-let"      | done   |                   |
-| ~lambda~                         | core     | arglist   |     1 | body     | "arg"            | done   |                   |
-| ~cl-destructuring-bind~          | core     | arglist   |     1 | body     | "arg"            | done   |                   |
-| ~cl-multiple-value-bind~         | core     | arglist   |     1 | body     | "cl-multi-vbind" | done   |                   |
-| ~cl-multiple-value-setq~         | core     | arglist   |     1 | body     | "cl-multi-vsetq" | done   |                   |
-| ~cl-with-gensyms~                | core     | arglist   |     1 | body     | "cl-wgensyms"    | done   |                   |
-| ~cl-once-only~                   | core     | arglist   |     1 | body     | "cl-once-only"   | done   |                   |
-| ~defun~                          | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~defmacro~                       | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~defsubst~                       | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~cl-defun~                       | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~cl-defmacro~                    | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~cl-defsubst~                    | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~define-inline~                  | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~cl-defgeneric~                  | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~iter-defun~                     | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~cl-iter-defun~                  | core     | arglist   |     2 | body     | "arg"            | done   |                   |
-| ~dolist~                         | core     | single    |     1 | body     | "dolist"         | done   |                   |
-| ~dotimes~                        | core     | single    |     1 | body     | "dotimes"        | done   |                   |
-| ~cl-do-symbols~                  | core     | single    |     1 | body     | "cl-do-symbols"  | done   |                   |
-| ~cl-do-all-symbols~              | core     | single    |     1 | body     | "cl-do-all-sym"  | done   |                   |
-| ~dolist-with-progress-reporter~  | core     | single    |     1 | body     | "dolist-pr"      | done   |                   |
-| ~dotimes-with-progress-reporter~ | core     | single    |     1 | body     | "dotimes-pr"     | done   |                   |
-| ~condition-case~                 | core     | error-var |     1 | handlers | "cond-case"      | done   |                   |
-| ~condition-case-unless-debug~    | core     | error-var |     1 | handlers | "cond-case"      | done   |                   |
-| ~ert-with-temp-file~             | core     | error-var |     1 | body     | "ert-tmp-file"   | done   |                   |
-| ~ert-with-temp-directory~        | core     | error-var |     1 | body     | "ert-tmp-dir"    | done   |                   |
-| ~ert-with-message-capture~       | core     | error-var |     1 | body     | "ert-msg-cap"    | done   |                   |
-| ~cl-defmethod~                   | core     | custom    |       |          | "cl-defmethod"   | done   | extract-defmethod |
-| ~cl-flet~                        | core     | custom    |       |          | "cl-flet"        | done   | extract-flet      |
-| ~cl-flet*~                       | core     | custom    |       |          | "cl-flet*"       | done   | extract-flet      |
-| ~cl-labels~                      | core     | custom    |       |          | "cl-labels"      | done   | extract-flet      |
-| ~cl-macrolet~                    | core     | custom    |       |          | "cl-macrolet"    | done   | extract-flet      |
-| ~cl-letf~                        | core     | custom    |       |          | "cl-letf"        | done   | extract-letf      |
-| ~cl-letf*~                       | core     | custom    |       |          | "cl-letf*"       | done   | extract-letf      |
-| ~cond-let--and-let*~             | cond-let | list      |     1 | body     | "cond-and-let*"  | done   |                   |
-| ~cond-let--and-let~              | cond-let | list      |     1 | body     | "cond-and-let"   | done   |                   |
-| ~cond-let--when-let*~            | cond-let | list      |     1 | body     | "cond-when-let*" | done   |                   |
-| ~cond-let--when-let~             | cond-let | list      |     1 | body     | "cond-when-let"  | done   |                   |
-| ~cond-let--while-let*~           | cond-let | list      |     1 | body     | "cond-while-let*"| done   |                   |
-| ~cond-let--while-let~            | cond-let | list      |     1 | body     | "cond-while-let" | done   |                   |
-| ~cond-let--if-let*~              | cond-let | list      |     1 | then     | "cond-if-let*"   | done   |                   |
-| ~cond-let--if-let~               | cond-let | list      |     1 | then     | "cond-if-let"    | done   |                   |
+| Symbol                           | Package  | Shape     | Index | Scope    | Tag                | Status | Extractor         |
+|----------------------------------+----------+-----------+-------+----------+--------------------+--------+-------------------|
+| ~let~                            | core     | list      |     1 | body     | "let"              | done   |                   |
+| ~let*~                           | core     | list      |     1 | body     | "let*"             | done   |                   |
+| ~when-let*~                      | core     | list      |     1 | body     | "when-let*"        | done   |                   |
+| ~and-let*~                       | core     | list      |     1 | body     | "and-let*"         | done   |                   |
+| ~dlet~                           | core     | list      |     1 | body     | "dlet"             | done   |                   |
+| ~letrec~                         | core     | list      |     1 | body     | "letrec"           | done   |                   |
+| ~cl-do~                          | core     | list      |     1 | body     | "cl-do"            | done   |                   |
+| ~cl-do*~                         | core     | list      |     1 | body     | "cl-do*"           | done   |                   |
+| ~cl-symbol-macrolet~             | core     | list      |     1 | body     | "cl-sym-mlet"      | done   |                   |
+| ~with-slots~                     | core     | list      |     1 | body     | "with-slots"       | done   |                   |
+| ~if-let~                         | core     | list      |     1 | then     | "if-let"           | done   |                   |
+| ~if-let*~                        | core     | list      |     1 | then     | "if-let*"          | done   |                   |
+| ~named-let~                      | core     | list      |     2 | body     | "named-let"        | done   |                   |
+| ~lambda~                         | core     | arglist   |     1 | body     | "arg"              | done   |                   |
+| ~cl-destructuring-bind~          | core     | arglist   |     1 | body     | "arg"              | done   |                   |
+| ~cl-multiple-value-bind~         | core     | arglist   |     1 | body     | "cl-multi-vbind"   | done   |                   |
+| ~cl-multiple-value-setq~         | core     | arglist   |     1 | body     | "cl-multi-vsetq"   | done   |                   |
+| ~cl-with-gensyms~                | core     | arglist   |     1 | body     | "cl-wgensyms"      | done   |                   |
+| ~cl-once-only~                   | core     | arglist   |     1 | body     | "cl-once-only"     | done   |                   |
+| ~defun~                          | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~defmacro~                       | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~defsubst~                       | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~cl-defun~                       | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~cl-defmacro~                    | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~cl-defsubst~                    | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~define-inline~                  | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~cl-defgeneric~                  | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~iter-defun~                     | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~cl-iter-defun~                  | core     | arglist   |     2 | body     | "arg"              | done   |                   |
+| ~dolist~                         | core     | single    |     1 | body     | "dolist"           | done   |                   |
+| ~dotimes~                        | core     | single    |     1 | body     | "dotimes"          | done   |                   |
+| ~cl-do-symbols~                  | core     | single    |     1 | body     | "cl-do-symbols"    | done   |                   |
+| ~cl-do-all-symbols~              | core     | single    |     1 | body     | "cl-do-all-sym"    | done   |                   |
+| ~dolist-with-progress-reporter~  | core     | single    |     1 | body     | "dolist-pr"        | done   |                   |
+| ~dotimes-with-progress-reporter~ | core     | single    |     1 | body     | "dotimes-pr"       | done   |                   |
+| ~condition-case~                 | core     | error-var |     1 | handlers | "cond-case"        | done   |                   |
+| ~condition-case-unless-debug~    | core     | error-var |     1 | handlers | "cond-case"        | done   |                   |
+| ~ert-with-temp-file~             | core     | error-var |     1 | body     | "ert-tmp-file"     | done   |                   |
+| ~ert-with-temp-directory~        | core     | error-var |     1 | body     | "ert-tmp-dir"      | done   |                   |
+| ~ert-with-message-capture~       | core     | error-var |     1 | body     | "ert-msg-cap"      | done   |                   |
+| ~cl-defmethod~                   | core     | custom    |       |          | "cl-defmethod"     | done   | extract-defmethod |
+| ~cl-flet~                        | core     | custom    |       |          | "cl-flet"          | done   | extract-flet      |
+| ~cl-flet*~                       | core     | custom    |       |          | "cl-flet*"         | done   | extract-flet      |
+| ~cl-labels~                      | core     | custom    |       |          | "cl-labels"        | done   | extract-flet      |
+| ~cl-macrolet~                    | core     | custom    |       |          | "cl-macrolet"      | done   | extract-flet      |
+| ~cl-letf~                        | core     | custom    |       |          | "cl-letf"          | done   | extract-letf      |
+| ~cl-letf*~                       | core     | custom    |       |          | "cl-letf*"         | done   | extract-letf      |
+| ~cond-let--and-let*~             | cond-let | list      |     1 | body     | "cond-and-let*"    | done   |                   |
+| ~cond-let--and-let~              | cond-let | list      |     1 | body     | "cond-and-let"     | done   |                   |
+| ~cond-let--when-let*~            | cond-let | list      |     1 | body     | "cond-when-let*"   | done   |                   |
+| ~cond-let--when-let~             | cond-let | list      |     1 | body     | "cond-when-let"    | done   |                   |
+| ~cond-let--while-let*~           | cond-let | list      |     1 | body     | "cond-while-let*"  | done   |                   |
+| ~cond-let--while-let~            | cond-let | list      |     1 | body     | "cond-while-let"   | done   |                   |
+| ~cond-let--if-let*~              | cond-let | list      |     1 | then     | "cond-if-let*"     | done   |                   |
+| ~cond-let--if-let~               | cond-let | list      |     1 | then     | "cond-if-let"      | done   |                   |
+| ~seq-let~                        | core     | list      |     1 | body     | "seq-let"          | done   | extract-seq-let   |
+| ~seq-doseq~                      | core     | single    |       |          | "doseq"            | done   |                   |
+| ~let-when-compile~               | core     | list      |     1 | body     | "let-when-compile" | done   |                   |
 
 
 - Deferred (core forms needing custom extractors) :: I'm leaving these for last,
   they're highly complex and I need a bit more time to understand their
-  signatures (specially cl-loop and dash). I'm going by order so first I'll
-  finish pcase and then move on to the others.
+  signatures (specially cl-loop and dash). I'm NOT going by order, got
+  sidetracked by other forms.
 
 | Symbol          | Package  | Reason                                             | Complexity | Status          |
 |-----------------+----------+----------------------------------------------------+------------+-----------------|
@@ -1294,10 +1297,11 @@ When looking at a macro's binding site, ask yourself:
   anything that you would then need to autocomplete. The other 3 are mostly
   trivial to implement but they're too niche, do let me know if you need them.
 
-| Symbol                  | Reason                              |
-|-------------------------+-------------------------------------|
-| ~cl-progv~                | Binding names determined at runtime |
-| ~cl-tagbody~              | No variable bindings                |
-| ~emacsql-with-connection~ | idk                                 |
-| ~evil-motion-loop~        | idk                                 |
-| ~org-dlet~                | idk                                 |
+| Symbol                    | Reason                                                              |
+|---------------------------+---------------------------------------------------------------------|
+| ~cl-progv~                | Binding names determined at runtime                                 |
+| ~cl-tagbody~              | No variable bindings                                                |
+| ~emacsql-with-connection~ | idk                                                                 |
+| ~evil-motion-loop~        | idk                                                                 |
+| ~org-dlet~                | idk                                                                 |
+| ~oclosure-lambda~         | not sure if worth it, mostly for internal usage within emacs source |

--- a/let-completion.el
+++ b/let-completion.el
@@ -603,6 +603,8 @@ Return SPEC or nil."
   '(:extractor let-completion--extract-pcase-dolist :tag "pcase-dolist"))
 (let-completion-register-binding-form 'pcase-lambda
   '(:extractor let-completion--extract-pcase-lambda :tag "pcase-λ"))
+(let-completion-register-binding-form 'map-let
+  '(:extractor let-completion--extract-map-let :tag "map-let"))
 
 
 ;;;; Scope Checking
@@ -1550,6 +1552,51 @@ Called by `let-completion--extract-bindings-at' via `:extractor'."
                       (push (list (symbol-name var) tag nil) result))))))
               result)))))))
 
+(cl-defun let-completion--extract-map-let (pos completion-pos tag)
+  "Extract bindings from a `map-let' form at POS.
+COMPLETION-POS is point.  TAG is the annotation label from the
+registry descriptor.
+
+Navigate past the head symbol to KEYS (index 1), then past MAP
+\(index 2).  Scope requires COMPLETION-POS past MAP.  Read KEYS
+via `read', extract variable names using
+`let-completion--pcase-map-vars'.
+
+Return alist of (NAME-STRING TAG-STRING nil) lists or nil.
+
+Used for `map-let'.
+Called by `let-completion--extract-bindings-at' via `:extractor'."
+  (save-excursion
+    (goto-char (1+ pos))
+    (forward-comment (buffer-size))
+    ;; -- Navigate: skip head symbol.
+    (let ((head-end (ignore-errors (scan-sexps (point) 1))))
+      (unless head-end (cl-return-from let-completion--extract-map-let))
+      (goto-char head-end)
+      (forward-comment (buffer-size))
+      ;; -- Navigate: read KEYS boundaries.
+      (let ((keys-start (point))
+            (keys-end (ignore-errors (scan-sexps (point) 1))))
+        (unless keys-end (cl-return-from let-completion--extract-map-let))
+        (goto-char keys-end)
+        (forward-comment (buffer-size))
+        ;; -- Navigate: skip MAP, check scope.
+        (let ((map-end (ignore-errors (scan-sexps (point) 1))))
+          (unless (and map-end (> completion-pos map-end))
+            (cl-return-from let-completion--extract-map-let))
+          ;; -- Read: parse KEYS and extract variable names.
+          (let ((keys (condition-case nil
+                          (car (read-from-string
+                                (buffer-substring-no-properties
+                                 keys-start keys-end)))
+                        (error nil))))
+            (when (listp keys)
+              (let ((vars (condition-case nil
+                              (let-completion--pcase-map-vars keys)
+                            (error nil))))
+                (mapcar (lambda (var)
+                          (list (symbol-name var) tag nil))
+                        vars)))))))))
 
 ;;;; Dispatcher
 

--- a/let-completion.el
+++ b/let-completion.el
@@ -562,6 +562,8 @@ Return SPEC or nil."
   '(:bindings-index 1 :binding-shape single :scope body :tag "dolist-pr"))
 (let-completion-register-binding-form 'dotimes-with-progress-reporter
   '(:bindings-index 1 :binding-shape single :scope body :tag "dotimes-pr"))
+(let-completion-register-binding-form 'seq-doseq
+  '(:bindings-index 1 :binding-shape single :scope body :tag "doseq"))
 
 ;;;;;; error-var shape: bare symbol
 

--- a/let-completion.el
+++ b/let-completion.el
@@ -594,6 +594,8 @@ Return SPEC or nil."
   '(:extractor let-completion--extract-letf :tag "cl-letf*"))
 (let-completion-register-binding-form 'cl-defmethod
   '(:extractor let-completion--extract-defmethod :tag "cl-defmethod"))
+(let-completion-register-binding-form 'seq-let
+  '(:extractor let-completion--extract-seq-let :tag "seq-let"))
 
 ;;;; Scope Checking
 
@@ -1163,6 +1165,57 @@ Called by `let-completion--extract-bindings-at' via `:extractor'."
                           (append entry (list context)))
                         bindings)
               bindings)))))))
+
+(cl-defun let-completion--extract-seq-let (pos completion-pos tag)
+  "Extract variable names from a `seq-let' form at POS.
+COMPLETION-POS is point.  TAG is the annotation label from the
+registry descriptor.
+
+Navigate past the head symbol to ARGS (index 1), then past
+SEQUENCE (index 2).  Scope requires COMPLETION-POS past
+SEQUENCE.  Walk ARGS collecting bare symbols, skipping `_',
+`&rest', and `&'-prefixed keywords.  ARGS may be a list or
+vector; `scan-sexps' handles both delimiter types.
+
+Return alist of (NAME-STRING TAG-STRING nil) lists or nil.
+
+Used for `seq-let'.
+Called by `let-completion--extract-bindings-at' via `:extractor'."
+  (save-excursion
+    (goto-char (1+ pos))
+    (forward-comment (buffer-size))
+    ;; -- Navigate: skip head symbol.
+    (let ((head-end (ignore-errors (scan-sexps (point) 1))))
+      (unless head-end (cl-return-from let-completion--extract-seq-let))
+      (goto-char head-end)
+      (forward-comment (buffer-size))
+      ;; -- Navigate: read ARGS boundaries.
+      (let* ((args-start (point))
+             (args-end (ignore-errors (scan-sexps (point) 1))))
+        (unless args-end (cl-return-from let-completion--extract-seq-let))
+        (goto-char args-end)
+        (forward-comment (buffer-size))
+        ;; -- Navigate: skip SEQUENCE, check scope.
+        (let ((seq-end (ignore-errors (scan-sexps (point) 1))))
+          (unless (and seq-end (> completion-pos seq-end))
+            (cl-return-from let-completion--extract-seq-let))
+          ;; -- Walk: collect symbols from ARGS.
+          (goto-char (1+ args-start))
+          (let (result)
+            (while (progn (forward-comment (buffer-size))
+                          (< (point) (1- args-end)))
+              (let ((sym-start (point)))
+                (condition-case nil
+                    (let* ((sym-end (scan-sexps (point) 1))
+                           (name (buffer-substring-no-properties
+                                  sym-start sym-end)))
+                      (unless (or (<= sym-start completion-pos sym-end)
+                                  (string-prefix-p "&" name)
+                                  (string= name "_"))
+                        (push (list name tag nil) result))
+                      (goto-char sym-end))
+                  (error (goto-char args-end)))))
+            result))))))
 
 ;;;; Dispatcher
 

--- a/let-completion.el
+++ b/let-completion.el
@@ -595,6 +595,15 @@ Return SPEC or nil."
   '(:extractor let-completion--extract-seq-let :tag "seq-let"))
 (let-completion-register-binding-form 'named-let
   '(:extractor let-completion--extract-named-let :tag "named-let"))
+(let-completion-register-binding-form 'pcase-let
+  '(:extractor let-completion--extract-pcase-let :tag "pcase-let"))
+(let-completion-register-binding-form 'pcase-let*
+  '(:extractor let-completion--extract-pcase-let :tag "pcase-let*"))
+(let-completion-register-binding-form 'pcase-dolist
+  '(:extractor let-completion--extract-pcase-dolist :tag "pcase-dolist"))
+(let-completion-register-binding-form 'pcase-lambda
+  '(:extractor let-completion--extract-pcase-lambda :tag "pcase-λ"))
+
 
 ;;;; Scope Checking
 
@@ -716,6 +725,123 @@ Called by `let-completion--extract-shape-arglist' and
                 (goto-char inner-end))
             (error (goto-char end)))))))
   result)
+
+;;;; Pcase Pattern Variable Extraction
+
+(defun let-completion--pcase-pattern-vars (pattern)
+  "Extract variable names from a pcase PATTERN.
+Walk the pattern recursively and return a list of symbol names
+that the pattern would bind when matched.
+
+Handle backquote patterns, `and', `or', `let', `pred', `guard',
+`app', `cl-struct', `map', and plain symbol patterns.  Skip `_',
+t, nil, and keyword symbols.
+
+Called by `let-completion--extract-pcase-let' and related
+extractors."
+  (pcase pattern
+    ;; Ignored or constant patterns.
+    ((or 'nil 't '_ '_) nil)
+    ;; Keyword symbols are literal matches, not bindings.
+    ((and (pred symbolp) (pred keywordp)) nil)
+    ;; Plain symbol: a variable binding.
+    ((and (pred symbolp) sym)
+     (let ((name (symbol-name sym)))
+       (if (or (string-prefix-p "_" name)
+               (member sym pcase--dontcare-upats))
+           nil
+         (list sym))))
+    ;; Backquote pattern: the reader produces (\` TEMPLATE).
+    ;; Match as a two-element list whose car is the symbol \`.
+    ((and (pred consp)
+          (guard (eq (car pattern) '\`))
+          (guard (consp (cdr pattern))))
+     (let-completion--pcase-backquote-vars (cadr pattern)))
+    ;; (and PAT1 PAT2 ...) -- collect vars from all sub-patterns.
+    (`(and . ,pats)
+     (mapcan #'let-completion--pcase-pattern-vars pats))
+    ;; (or PAT1 PAT2 ...) -- all branches bind the same vars;
+    ;; extract from the first.
+    (`(or . ,pats)
+     (when pats
+       (let-completion--pcase-pattern-vars (car pats))))
+    ;; (let PAT EXPR) -- extract vars from PAT.
+    (`(let ,pat . ,_)
+     (let-completion--pcase-pattern-vars pat))
+    ;; (app FN PAT) -- extract vars from PAT.
+    (`(app ,_ ,pat)
+     (let-completion--pcase-pattern-vars pat))
+    ;; (cl-struct TYPE FIELD1 FIELD2 ...) -- each field is a variable.
+    (`(cl-struct ,_ . ,fields)
+     (cl-loop for f in fields
+              when (and (symbolp f) (not (eq f '_))
+                        (not (keywordp f)))
+              collect f))
+    ;; (map KEY ...) or (map (KEY VAR) ...) -- from map.el pcase pattern.
+    (`(,(or 'map 'map!) . ,keys)
+     (let-completion--pcase-map-vars keys))
+    ;; (pred ...) and (guard ...) bind nothing.
+    (`(pred . ,_) nil)
+    (`(guard . ,_) nil)
+    ;; Quoted literal: binds nothing.
+    (`(quote . ,_) nil)
+    ;; Vector pattern.
+    ((pred vectorp)
+     (cl-loop for elt across pattern
+              nconc (let-completion--pcase-pattern-vars elt)))
+    ;; Unknown list pattern: ignore.
+    (_ nil)))
+
+(defun let-completion--pcase-backquote-vars (template)
+  "Extract variable names from a backquote TEMPLATE.
+TEMPLATE is the structure inside a \\=`...\\=` pattern after the
+reader has processed the backquote.
+
+Comma-unquoted positions (produced by the reader as =\\,' forms)
+are sub-patterns.  Everything else is a literal match.
+
+Called by `let-completion--pcase-pattern-vars'."
+  (cond
+   ;; ,PAT or ,@PAT -- the reader produces (\, PAT) or (\,@ PAT).
+   ((and (consp template)
+         (memq (car template) '(\, \,@)))
+    (let-completion--pcase-pattern-vars (cadr template)))
+   ;; Cons cell: recurse into car and cdr.
+   ((consp template)
+    (nconc (let-completion--pcase-backquote-vars (car template))
+           (let-completion--pcase-backquote-vars (cdr template))))
+   ;; Vector inside backquote template.
+   ((vectorp template)
+    (cl-loop for elt across template
+             nconc (let-completion--pcase-backquote-vars elt)))
+   ;; Atom (number, string, symbol, nil): literal match, no binding.
+   (t nil)))
+
+(defun let-completion--pcase-map-vars (keys)
+  "Extract variable names from map pattern KEYS.
+Each element is either a symbol KEY (binds KEY), a keyword :KEY
+\(binds a symbol derived from KEY without the colon), or a list
+\(KEY VAR) or (KEY VAR DEFAULT) where VAR is the bound variable.
+
+Called by `let-completion--pcase-pattern-vars'."
+  (cl-loop for k in keys
+           nconc (cond
+                  ;; (KEY VAR) or (KEY VAR DEFAULT)
+                  ((and (consp k) (cdr k))
+                   (let ((var (cadr k)))
+                     (when (and (symbolp var) (not (eq var '_)))
+                       (list var))))
+                  ;; :keyword -- binds symbol without colon prefix
+                  ((keywordp k)
+                   (let ((name (substring (symbol-name k) 1)))
+                     (unless (string-empty-p name)
+                       (list (intern name)))))
+                  ;; Plain symbol
+                  ((and (symbolp k) (not (eq k '_))
+                        (not (eq k t)) (not (eq k nil)))
+                   (list k))
+                  (t nil))))
+
 
 ;;;; Shape Extractors
 
@@ -956,7 +1082,7 @@ Called by `let-completion--extract-shape'."
       (unless (or (string-empty-p name) (string= name "nil"))
         (list (list name tag nil))))))
 
-;;; Custom Extractor Functions
+;;;; Custom Extractor Functions
 
 (cl-defun let-completion--extract-flet (pos completion-pos tag)
   "Extract function names from a flet-like form at POS.
@@ -1265,6 +1391,165 @@ Called by `let-completion--extract-bindings-at' via `:extractor'."
                                       (append entry (list name)))
                                     bindings)))
               (cons name-entry bindings))))))))
+
+(cl-defun let-completion--extract-pcase-let (pos completion-pos tag)
+  "Extract bindings from a `pcase-let' or `pcase-let*' form at POS.
+COMPLETION-POS is point.  TAG is the annotation label from the
+registry descriptor.
+
+Navigate past the head symbol to the binding list at index 1.
+Each entry is (PATTERN EXPR).  Read each entry via `read', walk
+the pattern with `let-completion--pcase-pattern-vars' to extract
+variable names.  Values are extracted via `read' from the EXPR
+position.  Scope requires COMPLETION-POS past the binding list.
+
+Return alist of (NAME-STRING TAG-STRING VALUE-OR-NIL) lists or nil.
+
+Used for `pcase-let', `pcase-let*'.
+Called by `let-completion--extract-bindings-at' via `:extractor'."
+  (save-excursion
+    (goto-char (1+ pos))
+    (forward-comment (buffer-size))
+    ;; -- Navigate: skip head symbol.
+    (let ((head-end (ignore-errors (scan-sexps (point) 1))))
+      (unless head-end (cl-return-from let-completion--extract-pcase-let))
+      (goto-char head-end)
+      (forward-comment (buffer-size))
+      ;; -- Navigate: now at binding list.
+      (let ((list-start (point))
+            (list-end (ignore-errors (scan-sexps (point) 1))))
+        (unless (and list-end
+                     (eq (char-after list-start) ?\()
+                     (> completion-pos list-end))
+          (cl-return-from let-completion--extract-pcase-let))
+        ;; -- Walk: iterate entries in binding list.
+        (goto-char (1+ list-start))
+        (let (result)
+          (while (progn (forward-comment (buffer-size))
+                        (< (point) (1- list-end)))
+            (let ((entry-start (point)))
+              (condition-case nil
+                  (let ((entry-end (scan-sexps (point) 1)))
+                    (if (<= entry-start completion-pos entry-end)
+                        (goto-char entry-end)
+                      (when (eq (char-after entry-start) ?\()
+                        ;; -- Entry: read the (PATTERN EXPR) form.
+                        (let ((entry (condition-case nil
+                                         (car (read-from-string
+                                               (buffer-substring-no-properties
+                                                entry-start entry-end)))
+                                       (error nil))))
+                          (when (and entry (consp entry))
+                            (let* ((pattern (car entry))
+                                   (value (cadr entry))
+                                   (vars (condition-case nil
+                                             (let-completion--pcase-pattern-vars
+                                              pattern)
+                                           (error nil))))
+                              (dolist (var vars)
+                                (push (list (symbol-name var) tag value)
+                                      result))))))
+                      (goto-char entry-end)))
+                (error (goto-char list-end)))))
+          result)))))
+
+(cl-defun let-completion--extract-pcase-dolist (pos completion-pos tag)
+  "Extract bindings from a `pcase-dolist' form at POS.
+COMPLETION-POS is point.  TAG is the annotation label from the
+registry descriptor.
+
+Navigate past the head symbol to the spec at index 1, which has
+the structure (PATTERN LIST).  Read the spec, extract variables
+from PATTERN.  Scope requires COMPLETION-POS past the spec.
+
+Return alist of (NAME-STRING TAG-STRING nil) lists or nil.
+
+Used for `pcase-dolist'.
+Called by `let-completion--extract-bindings-at' via `:extractor'."
+  (save-excursion
+    (goto-char (1+ pos))
+    (forward-comment (buffer-size))
+    ;; -- Navigate: skip head symbol.
+    (let ((head-end (ignore-errors (scan-sexps (point) 1))))
+      (unless head-end (cl-return-from let-completion--extract-pcase-dolist))
+      (goto-char head-end)
+      (forward-comment (buffer-size))
+      ;; -- Navigate: read the (PATTERN LIST) spec.
+      (let ((spec-start (point))
+            (spec-end (ignore-errors (scan-sexps (point) 1))))
+        (unless (and spec-end
+                     (eq (char-after spec-start) ?\()
+                     (> completion-pos spec-end))
+          (cl-return-from let-completion--extract-pcase-dolist))
+        ;; -- Read: parse spec and extract pattern.
+        (let ((spec (condition-case nil
+                        (car (read-from-string
+                              (buffer-substring-no-properties
+                               spec-start spec-end)))
+                      (error nil))))
+          (when (and spec (consp spec))
+            (let ((vars (condition-case nil
+                            (let-completion--pcase-pattern-vars (car spec))
+                          (error nil))))
+              (mapcar (lambda (var)
+                        (list (symbol-name var) tag nil))
+                      vars))))))))
+
+(cl-defun let-completion--extract-pcase-lambda (pos completion-pos tag)
+  "Extract bindings from a `pcase-lambda' form at POS.
+COMPLETION-POS is point.  TAG is the annotation label from the
+registry descriptor.
+
+Navigate past the head symbol to the arglist at index 1.  Each
+element is either a plain symbol (collected as-is) or a pcase
+pattern (walked for variables).  Scope requires COMPLETION-POS
+past the arglist.
+
+Return alist of (NAME-STRING TAG-STRING nil) lists or nil.
+
+Used for `pcase-lambda'.
+Called by `let-completion--extract-bindings-at' via `:extractor'."
+  (save-excursion
+    (goto-char (1+ pos))
+    (forward-comment (buffer-size))
+    ;; -- Navigate: skip head symbol.
+    (let ((head-end (ignore-errors (scan-sexps (point) 1))))
+      (unless head-end (cl-return-from let-completion--extract-pcase-lambda))
+      (goto-char head-end)
+      (forward-comment (buffer-size))
+      ;; -- Navigate: read arglist.
+      (let ((arglist-start (point))
+            (arglist-end (ignore-errors (scan-sexps (point) 1))))
+        (unless (and arglist-end
+                     (eq (char-after arglist-start) ?\()
+                     (> completion-pos arglist-end))
+          (cl-return-from let-completion--extract-pcase-lambda))
+        ;; -- Read: parse arglist.
+        (let ((arglist (condition-case nil
+                           (car (read-from-string
+                                 (buffer-substring-no-properties
+                                  arglist-start arglist-end)))
+                         (error nil))))
+          (when (listp arglist)
+            (let (result)
+              (dolist (arg arglist)
+                (cond
+                 ;; Lambda-list keyword: skip.
+                 ((and (symbolp arg) (string-prefix-p "&" (symbol-name arg)))
+                  nil)
+                 ;; Plain symbol: collect directly.
+                 ((and (symbolp arg) (not (memq arg '(_ t nil)))
+                       (not (keywordp arg)))
+                  (push (list (symbol-name arg) tag nil) result))
+                 ;; Pattern: extract variables.
+                 (t
+                  (let ((vars (condition-case nil
+                                  (let-completion--pcase-pattern-vars arg)
+                                (error nil))))
+                    (dolist (var vars)
+                      (push (list (symbol-name var) tag nil) result))))))
+              result)))))))
+
 
 ;;;; Dispatcher
 

--- a/let-completion.el
+++ b/let-completion.el
@@ -506,9 +506,6 @@ Return SPEC or nil."
 (let-completion-register-binding-form 'if-let*
   '(:bindings-index 1 :binding-shape list :scope then :tag "if-let*"))
 
-;; Index 2, body scope.
-(let-completion-register-binding-form 'named-let
-  '(:bindings-index 2 :binding-shape list :scope body :tag "named-let"))
 
 ;;;;;; arglist shape: (ARG &optional ARG2 &rest ARG3) parameters
 
@@ -596,6 +593,8 @@ Return SPEC or nil."
   '(:extractor let-completion--extract-defmethod :tag "cl-defmethod"))
 (let-completion-register-binding-form 'seq-let
   '(:extractor let-completion--extract-seq-let :tag "seq-let"))
+(let-completion-register-binding-form 'named-let
+  '(:extractor let-completion--extract-named-let :tag "named-let"))
 
 ;;;; Scope Checking
 
@@ -1216,6 +1215,56 @@ Called by `let-completion--extract-bindings-at' via `:extractor'."
                       (goto-char sym-end))
                   (error (goto-char args-end)))))
             result))))))
+
+(cl-defun let-completion--extract-named-let (pos completion-pos tag)
+  "Extract bindings from a `named-let' form at POS.
+COMPLETION-POS is point.  TAG is the annotation label from the
+registry descriptor.
+
+Navigate past the head symbol to NAME (index 1), which is bound
+as a local recursive function visible in BODY.  Capture NAME as
+context string.  Read BINDINGS (index 2) as list-shaped bindings.
+Check scope: COMPLETION-POS must be past the bindings sexp.
+
+Return alist of (NAME-STRING TAG-STRING VALUE-OR-NIL CONTEXT)
+lists or nil.
+
+Used for `named-let'.
+Called by `let-completion--extract-bindings-at' via `:extractor'."
+  (save-excursion
+    (goto-char (1+ pos))
+    (forward-comment (buffer-size))
+    ;; -- Navigate: skip head symbol.
+    (let ((head-end (ignore-errors (scan-sexps (point) 1))))
+      (unless head-end (cl-return-from let-completion--extract-named-let))
+      (goto-char head-end)
+      (forward-comment (buffer-size))
+      ;; -- Navigate: read NAME as function binding and context.
+      (let* ((name-start (point))
+             (name-end (ignore-errors (scan-sexps (point) 1))))
+        (unless name-end (cl-return-from let-completion--extract-named-let))
+        (let ((name (buffer-substring-no-properties name-start name-end)))
+          (goto-char name-end)
+          (forward-comment (buffer-size))
+          ;; -- Navigate: read BINDINGS boundaries.
+          (let ((bindings-start (point))
+                (bindings-end (ignore-errors (scan-sexps (point) 1))))
+            (unless bindings-end
+              (cl-return-from let-completion--extract-named-let))
+            ;; -- Scope: completion must be past bindings.
+            (unless (> completion-pos bindings-end)
+              (cl-return-from let-completion--extract-named-let))
+            ;; -- Extract: list-shaped bindings from BINDINGS sexp.
+            (let* ((bindings (let-completion--extract-shape-list
+                              bindings-start bindings-end
+                              completion-pos tag))
+                   ;; -- Entry: NAME as local function binding.
+                   (name-entry (list name "fn" nil name))
+                   ;; -- Attach: inject context into binding entries.
+                   (bindings (mapcar (lambda (entry)
+                                      (append entry (list name)))
+                                    bindings)))
+              (cons name-entry bindings))))))))
 
 ;;;; Dispatcher
 

--- a/let-completion.el
+++ b/let-completion.el
@@ -497,6 +497,8 @@ Return SPEC or nil."
   '(:bindings-index 1 :binding-shape list :scope body :tag "cl-sym-mlet"))
 (let-completion-register-binding-form 'with-slots
   '(:bindings-index 1 :binding-shape list :scope body :tag "with-slots"))
+(let-completion-register-binding-form 'let-when-compile
+  '(:bindings-index 1 :binding-shape list :scope body :tag "let-when-compile"))
 
 ;; Index 1, then scope.
 (let-completion-register-binding-form 'if-let


### PR DESCRIPTION
New registered binding forms, add support for:

-   `let-when-compile`
-   `seq-doseq`
-   `seq-let`
-   `named-let`
-   `pcase-let`
-   `pcase-let*`
-   `pcase-dolist`
-   `pcase-lambda`
-   `map-let`
